### PR TITLE
add missing constructor for HTML_QuickForm_Renderer_Default

### DIFF
--- a/lib/HTML/QuickForm/Renderer/Default.php
+++ b/lib/HTML/QuickForm/Renderer/Default.php
@@ -124,6 +124,14 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     */
     var $_hiddenHtml = '';
 
+    /**
+     * Compatibility with parent::__construct() calls from inherited classes
+     */
+    public function __construct()
+    {
+
+    }
+
    /**
     * returns the HTML generated for the form
     *


### PR DESCRIPTION
this will fix errors from inherited class `HTML_QuickForm_Renderer_QuickHtml` constructor function, which explicitly calls parent::__construct() and produces a fatal error.